### PR TITLE
Reconfigure xarray update

### DIFF
--- a/ngen_forcing/defs.py
+++ b/ngen_forcing/defs.py
@@ -16,3 +16,11 @@ def xr_read_window(ds, window, mask=None):
         return data
     else:
         return data.where(mask)
+
+
+def xr_read_window_time(ds, window, mask=None, idx=None, time=None):
+    data = ds.isel(window)
+    if mask is None:
+        return idx, time, data
+    else:
+        return idx, time, data.where(mask)

--- a/ngen_forcing/test_process_nwm_forcing_to_ngen.py
+++ b/ngen_forcing/test_process_nwm_forcing_to_ngen.py
@@ -49,7 +49,8 @@ wget -P 03w -c https://nextgen-hydrofabric.s3.amazonaws.com/v1.2/nextgen_03W.gpk
 
 
 def get_forcing_dict(
-    gpkg_divides,
+    feature_index,
+    feature_list,
     folder_prefix,
     filelist,
     var_list,
@@ -59,7 +60,7 @@ def get_forcing_dict(
 
     df_dict = {}
     for _v in var_list:
-        df_dict[_v] = pd.DataFrame(index=gpkg_divides.index)
+        df_dict[_v] = pd.DataFrame(index=feature_index)
 
     ds_list = []
     for _nc_file in filelist:
@@ -77,7 +78,7 @@ def get_forcing_dict(
                 _arr2 = _src.values[0]
 
                 _df_zonal_stats = pd.DataFrame(
-                    zonal_stats(gpkg_divides, _arr2, affine=_aff2)
+                    zonal_stats(feature_list, _arr2, affine=_aff2)
                 )
                 # if adding statistics back to original GeoDataFrame
                 # gdf3 = pd.concat([gpkg_divides, _df_zonal_stats], axis=1)
@@ -121,10 +122,12 @@ def main():
 
     # This way is extremely slow for anything more than a
     # few files, so we comment it out of the test
+
     start_time = time.time()
     print(f"Working on the old (slow) way")
     fd1 = get_forcing_dict(
-        gpkg_subset,
+        gpkg_subset.index,
+        feature_list,
         folder_prefix,
         file_list,
         var_list,
@@ -142,7 +145,7 @@ def main():
 
     start_time = time.time()
     print(f"Working on the new way with threading parallel.")
-    fd3 = get_forcing_dict_newway_parallel(
+    fd3t = get_forcing_dict_newway_parallel(
         feature_list,
         folder_prefix,
         file_list,
@@ -153,7 +156,7 @@ def main():
 
     start_time = time.time()
     print(f"Working on the new way with process parallel.")
-    fd3 = get_forcing_dict_newway_parallel(
+    fd3p = get_forcing_dict_newway_parallel(
         feature_list,
         folder_prefix,
         file_list,
@@ -173,7 +176,7 @@ def main():
 
     start_time = time.time()
     print(f"Working on the new way with loops reversed with threading parallel.")
-    fd4 = get_forcing_dict_newway_inverted_parallel(
+    fd5t = get_forcing_dict_newway_inverted_parallel(
         feature_list,
         folder_prefix,
         file_list,
@@ -184,7 +187,7 @@ def main():
 
     start_time = time.time()
     print(f"Working on the new way with loops reversed with process parallel.")
-    fd4 = get_forcing_dict_newway_inverted_parallel(
+    fd5p = get_forcing_dict_newway_inverted_parallel(
         feature_list,
         folder_prefix,
         file_list,

--- a/ngen_forcing/test_process_nwm_forcing_to_ngen.py
+++ b/ngen_forcing/test_process_nwm_forcing_to_ngen.py
@@ -137,9 +137,11 @@ def main():
     start_time = time.time()
     print(f"Working on the new way")
     fd2 = get_forcing_dict_newway(
+        gpkg_subset.index,
         feature_list,
         folder_prefix,
         file_list,
+        var_list,
     )
     print(time.time() - start_time)
 
@@ -168,9 +170,11 @@ def main():
     start_time = time.time()
     print(f"Working on the new way with loops reversed.")
     fd4 = get_forcing_dict_newway_inverted(
+        gpkg_subset.index,
         feature_list,
         folder_prefix,
         file_list,
+        var_list,
     )
     print(time.time() - start_time)
 

--- a/ngen_forcing/test_process_nwm_forcing_to_ngen.py
+++ b/ngen_forcing/test_process_nwm_forcing_to_ngen.py
@@ -148,9 +148,11 @@ def main():
     start_time = time.time()
     print(f"Working on the new way with threading parallel.")
     fd3t = get_forcing_dict_newway_parallel(
+        gpkg_subset.index,
         feature_list,
         folder_prefix,
         file_list,
+        var_list,
         para="thread",
         para_n=16,
     )
@@ -159,9 +161,11 @@ def main():
     start_time = time.time()
     print(f"Working on the new way with process parallel.")
     fd3p = get_forcing_dict_newway_parallel(
+        gpkg_subset.index,
         feature_list,
         folder_prefix,
         file_list,
+        var_list,
         para="process",
         para_n=16,
     )
@@ -181,9 +185,11 @@ def main():
     start_time = time.time()
     print(f"Working on the new way with loops reversed with threading parallel.")
     fd5t = get_forcing_dict_newway_inverted_parallel(
+        gpkg_subset.index,
         feature_list,
         folder_prefix,
         file_list,
+        var_list,
         para="thread",
         para_n=16,
     )
@@ -192,9 +198,11 @@ def main():
     start_time = time.time()
     print(f"Working on the new way with loops reversed with process parallel.")
     fd5p = get_forcing_dict_newway_inverted_parallel(
+        gpkg_subset.index,
         feature_list,
         folder_prefix,
         file_list,
+        var_list,
         para="process",
         para_n=16,
     )


### PR DESCRIPTION
This update rebases the changes from updated_xarray_methods onto the latest changes from the ngen_forcing branch in the upstream. 

The upstream changes include some of the updates from the former, so the merge is a bit messy, unfortunately. 

Git modifications to the updated_xarray_methods include removing indexing anomalies (`j+=1`), using only the index and feature list of the geopackage instead of the full object (which may not have yielded significant benefits) and an attempt to use similar syntax for forming the dictionaries in each of the functions. It would be helpful to include a separate helper function to perform the translation. 

**NOTE:** in the process of examining [this pull request](https://github.com/jameshalgren/data-access-examples/pull/1) which is the root of the updated_xarray_methods branch, we noticed that the parallel methods only work when the raster engine is not set to `rasterio`... BUT then the calculation doesn't produce the right answer. So... another bug to track down. It may not be possible to do this in parallel. 